### PR TITLE
Chainpoint Package for anchoring data to public blockchains

### DIFF
--- a/chainpoint.go
+++ b/chainpoint.go
@@ -1,4 +1,4 @@
-package chainpoint
+package provide
 
 import (
 	"bytes"
@@ -68,7 +68,7 @@ type VerifiedProofs []struct {
 func init() {
 	randomNodes, err := GetNodes()
 	if err != nil {
-		log.Fatalf("FAILURE : INIT : failed to retrieve chainpoint nodes from service discovery")
+		Log.ErrorF("Failed to retrieve chainpoint nodes from service discovery")
 	} else {
 		RANDOM_NODES = randomNodes
 	}
@@ -79,14 +79,14 @@ func GetNodes() (NodeList, error) {
 	var randomNodes NodeList
 	res, err := http.Get("http://a.chainpoint.org/nodes/random")
 	if err != nil {
-		log.Fatalf("GET_RANDOM_NODES : FAILURE : %s", err)
+		Log.ErrorF("Failed to make HTTP GET request to fetch a list of random Chainpoint Nodes; %s", err.Error())
 		return nil, err
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		log.Fatalf("GET_RANDOM_NODES : FAILURE : %s", err)
+		Log.ErrorF("Failed to read GET request to retrieve random Chainpoint Nodes; %s", err.Error())
 		return nil, err
 	}
 	json.Unmarshal(body, &randomNodes)
@@ -141,8 +141,8 @@ func GetProofs(proofHandles []ProofHandle) ([]ProofBody, error) {
 
 	proofHandlesMap, ok := v.(map[string][]ProofHandle)
 	if !ok {
-		log.Printf("GET_PROOFS : FAILURE : GroupBy : not able to group by uri")
-		return nil, errors.New("error create ProofHandles Map")
+		Log.WarningF("Failed to group ProofHandles by uri")
+		return nil, errors.New("Error creating ProofHandles Map")
 	}
 
 	for uri, values := range proofHandlesMap {
@@ -186,7 +186,7 @@ func VerifyProofs(proofs []string) (VerifiedProofs, error) {
 
 	res, err := http.Post(fmt.Sprintf("%s/verify", RANDOM_NODES[0].PublicUri), "application/json", bytes.NewBuffer(bodyBytes))
 	if err != nil {
-		log.Fatalf("FAILURE : VERIFY_PROOFS : %s", err)
+		Log.WarningF("Failed to verify Proofs; %s", err.Error())
 		return nil, err
 	}
 	defer res.Body.Close()
@@ -217,7 +217,7 @@ func getProofsFromNode(queue chan []ProofBody, w *sync.WaitGroup, uri string, ha
 	res, err := client.Do(req)
 	if err != nil {
 		w.Add(-1)
-		log.Printf("FAILURE : GET_PROOFS : GET : URI=%s : %s\n", uri, err)
+		Log.WarningF("Failed to retrieve Proofs from URI=%s; %s\n", uri, err.Error())
 		return
 	}
 	defer res.Body.Close()
@@ -240,7 +240,7 @@ func submitHashesToNode(queue chan SubmitHashesResponse, w *sync.WaitGroup, uri 
 	res, err := http.Post(fmt.Sprintf("%s/hashes", uri.PublicUri), "application/json", bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		w.Add(-1)
-		log.Printf("SUBMIT_HASHES : FAILURE : POST : URI=%s : %s\n", uri.PublicUri, err)
+		Log.WarningF("Failed to submit hashes to Chainpoint Node URI=%s; %s\n", uri.PublicUri, err.Error())
 		return
 	}
 	defer res.Body.Close()

--- a/chainpoint.go
+++ b/chainpoint.go
@@ -1,0 +1,254 @@
+package chainpoint
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	underscore "github.com/ahl5esoft/golang-underscore"
+)
+
+type Node struct {
+	PublicUri string `json:"public_uri"`
+}
+
+type NodeList []Node
+
+var RANDOM_NODES NodeList
+
+type SubmitHashesResponse struct {
+	Meta struct {
+		SubmittedAt     time.Time `json:"submitted_at"`
+		SubmittedTo     string    `json:"submitted_to"`
+		ProcessingHints struct {
+			Cal time.Time `json:"cal"`
+			Btc time.Time `json:"btc"`
+		} `json:"processing_hints"`
+	} `json:"meta"`
+	Hashes []struct {
+		HashIDNode string `json:"hash_id_node"`
+		Hash       string `json:"hash"`
+	} `json:"hashes"`
+}
+
+type ProofHandle struct {
+	Hash       string `json:"hash"`
+	HashIDNode string `json:"hashIdNode"`
+	Uri        string `json:"uri"`
+}
+
+type ProofBody struct {
+	Anchors    []interface{} `json:"anchors_complete"`
+	HashIDNode string        `json:"hash_id_node"`
+	Proof      interface{}   `json:"proof"`
+}
+
+type VerifiedProofs []struct {
+	ProofIndex          int       `json:"proof_index"`
+	Hash                string    `json:"hash"`
+	HashIDNode          string    `json:"hash_id_node"`
+	HashSubmittedNodeAt time.Time `json:"hash_submitted_node_at"`
+	HashIDCore          string    `json:"hash_id_core"`
+	HashSubmittedCoreAt time.Time `json:"hash_submitted_core_at"`
+	Anchors             []struct {
+		Branch string `json:"branch"`
+		Type   string `json:"type"`
+		Valid  bool   `json:"valid"`
+	} `json:"anchors"`
+	Status string `json:"status"`
+}
+
+func init() {
+	randomNodes, err := GetNodes()
+	if err != nil {
+		log.Fatalf("FAILURE : INIT : failed to retrieve chainpoint nodes from service discovery")
+	} else {
+		RANDOM_NODES = randomNodes
+	}
+}
+
+// Will retrieve a list of 25 random Chainpoint Nodes.
+func GetNodes() (NodeList, error) {
+	var randomNodes NodeList
+	res, err := http.Get("http://a.chainpoint.org/nodes/random")
+	if err != nil {
+		log.Fatalf("GET_RANDOM_NODES : FAILURE : %s", err)
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Fatalf("GET_RANDOM_NODES : FAILURE : %s", err)
+		return nil, err
+	}
+	json.Unmarshal(body, &randomNodes)
+
+	return randomNodes, nil
+}
+
+// The SubmitHashes function will submit a list of hashes to every Chainpoint Node
+// provided to it via the function's first argument `uris` of type `NodeList`.
+// Submitting to multiple Chainpoint Nodes to achieve your required level of redundancy is advised.
+// Only a single Chainpoint Proof is required to attest the existence of your data.
+func SubmitHashes(uris NodeList, hashes []string) ([]ProofHandle, error) {
+	nodeResponseQueue := make(chan SubmitHashesResponse)
+
+	var wg sync.WaitGroup
+	wg.Add(len(uris))
+
+	for _, uri := range uris {
+		go submitHashesToNode(nodeResponseQueue, &wg, uri, hashes)
+	}
+
+	go func() {
+		wg.Wait()
+		close(nodeResponseQueue)
+	}()
+
+	var proofHandleSlice []ProofHandle
+	for nodeResponse := range nodeResponseQueue {
+		nodeUri := nodeResponse.Meta.SubmittedTo
+
+		for i := 0; i < len(nodeResponse.Hashes); i++ {
+			proofHandleSlice = append(proofHandleSlice, ProofHandle{Uri: nodeUri, HashIDNode: nodeResponse.Hashes[i].HashIDNode, Hash: nodeResponse.Hashes[i].Hash})
+		}
+	}
+
+	if len(proofHandleSlice) >= 1 {
+		return proofHandleSlice, nil
+	} else {
+		return nil, errors.New("error submitting hashes to Chainpoint Node(s)")
+	}
+}
+
+// The GetProofs function accepts a list of Proof Handles and will retrieve their corresponding Chainpoint Proofs.
+// This function includes the subtle optimization of grouping Proof Handles by Chainpoint Node PublicUri's and will issue
+// one HTTP GET request with an embedded header value consisting of a comma-delimited string of hashIdNode values dictating which
+// Proofs need to be resolved and returned to the requestor.
+func GetProofs(proofHandles []ProofHandle) ([]ProofBody, error) {
+	var wg sync.WaitGroup
+	getProofsResponseQueue := make(chan []ProofBody)
+
+	v := underscore.GroupBy(proofHandles, "uri")
+
+	proofHandlesMap, ok := v.(map[string][]ProofHandle)
+	if !ok {
+		log.Printf("GET_PROOFS : FAILURE : GroupBy : not able to group by uri")
+		return nil, errors.New("error create ProofHandles Map")
+	}
+
+	for uri, values := range proofHandlesMap {
+		wg.Add(1)
+		handlesByUri := underscore.Map(values, func(currVal ProofHandle, _ int) string {
+			return currVal.HashIDNode
+		})
+		hashIds, _ := handlesByUri.([]string)
+
+		go getProofsFromNode(getProofsResponseQueue, &wg, uri, hashIds)
+	}
+
+	go func() {
+		wg.Wait()
+		close(getProofsResponseQueue)
+	}()
+
+	var proofsSlice []ProofBody
+	for proofsFromNode := range getProofsResponseQueue {
+		for _, proof := range proofsFromNode {
+			proofsSlice = append(proofsSlice, proof)
+		}
+	}
+
+	if len(proofsSlice) > 1 {
+		return proofsSlice, nil
+	} else {
+		return nil, errors.New("error fetching proofs from chainpoint nodes")
+	}
+}
+
+// The VerifyProofs function accepts a list of base64 encode strings that will be submitted to any Chainpoint Node for verification.
+// The verification process will perform the required cryptorgraphic operations for both `cal` and `btc` branches to
+// verify the integrity of the Chainpoint Proof(s) that have been submitted.
+func VerifyProofs(proofs []string) (VerifiedProofs, error) {
+	var verifiedProofs VerifiedProofs
+	body := map[string][]string{
+		"proofs": proofs,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	res, err := http.Post(fmt.Sprintf("%s/verify", RANDOM_NODES[0].PublicUri), "application/json", bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		log.Fatalf("FAILURE : VERIFY_PROOFS : %s", err)
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	json.NewDecoder(res.Body).Decode(&verifiedProofs)
+
+	return verifiedProofs, nil
+}
+
+/**
+ * Helper functions
+ *
+ * 1) submitHashesToNode
+ * 2) getProofsFromNode
+ */
+
+// Will retrieve a list of Proofs from a particular Chainpoint Node. Multiple HashIDNode values
+// are supported and will be transformed into a comma-delimited list that will be included as part of
+// a header for the HTTP GET request to a Node's /proofs endpoint.
+func getProofsFromNode(queue chan []ProofBody, w *sync.WaitGroup, uri string, hashIds []string) {
+	defer w.Done()
+	var getProofResponse []ProofBody
+
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", fmt.Sprintf("%s/proofs", uri), nil)
+	req.Header.Set("hashids", strings.Join(hashIds, ","))
+
+	res, err := client.Do(req)
+	if err != nil {
+		w.Add(-1)
+		log.Printf("FAILURE : GET_PROOFS : GET : URI=%s : %s\n", uri, err)
+		return
+	}
+	defer res.Body.Close()
+
+	json.NewDecoder(res.Body).Decode(&getProofResponse)
+
+	queue <- getProofResponse
+}
+
+// Will submit a list of hashes to a Chainpoint Node. This function will make a HTTP Post request to the
+// /hashes endpoint of the node and on a 200 response, return an array of ProofHandles.
+func submitHashesToNode(queue chan SubmitHashesResponse, w *sync.WaitGroup, uri Node, hashes []string) {
+	defer w.Done()
+	var submitHashesResponse SubmitHashesResponse
+	body := map[string][]string{
+		"hashes": hashes,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	res, err := http.Post(fmt.Sprintf("%s/hashes", uri.PublicUri), "application/json", bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		w.Add(-1)
+		log.Printf("SUBMIT_HASHES : FAILURE : POST : URI=%s : %s\n", uri.PublicUri, err)
+		return
+	}
+	defer res.Body.Close()
+
+	json.NewDecoder(res.Body).Decode(&submitHashesResponse)
+
+	// Mutate the submitHashesResponse to include the uri that received the hashes
+	submitHashesResponse.Meta.SubmittedTo = uri.PublicUri
+
+	queue <- submitHashesResponse
+}

--- a/chainpoint.go
+++ b/chainpoint.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -68,7 +67,7 @@ type VerifiedProofs []struct {
 func init() {
 	randomNodes, err := GetNodes()
 	if err != nil {
-		Log.ErrorF("Failed to retrieve chainpoint nodes from service discovery")
+		Log.Errorf("Failed to retrieve chainpoint nodes from service discovery")
 	} else {
 		RANDOM_NODES = randomNodes
 	}
@@ -79,14 +78,14 @@ func GetNodes() (NodeList, error) {
 	var randomNodes NodeList
 	res, err := http.Get("http://a.chainpoint.org/nodes/random")
 	if err != nil {
-		Log.ErrorF("Failed to make HTTP GET request to fetch a list of random Chainpoint Nodes; %s", err.Error())
+		Log.Errorf("Failed to make HTTP GET request to fetch a list of random Chainpoint Nodes; %s", err.Error())
 		return nil, err
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		Log.ErrorF("Failed to read GET request to retrieve random Chainpoint Nodes; %s", err.Error())
+		Log.Errorf("Failed to read GET request to retrieve random Chainpoint Nodes; %s", err.Error())
 		return nil, err
 	}
 	json.Unmarshal(body, &randomNodes)
@@ -141,7 +140,7 @@ func GetProofs(proofHandles []ProofHandle) ([]ProofBody, error) {
 
 	proofHandlesMap, ok := v.(map[string][]ProofHandle)
 	if !ok {
-		Log.WarningF("Failed to group ProofHandles by uri")
+		Log.Warningf("Failed to group ProofHandles by uri")
 		return nil, errors.New("Error creating ProofHandles Map")
 	}
 
@@ -186,7 +185,7 @@ func VerifyProofs(proofs []string) (VerifiedProofs, error) {
 
 	res, err := http.Post(fmt.Sprintf("%s/verify", RANDOM_NODES[0].PublicUri), "application/json", bytes.NewBuffer(bodyBytes))
 	if err != nil {
-		Log.WarningF("Failed to verify Proofs; %s", err.Error())
+		Log.Warningf("Failed to verify Proofs; %s", err.Error())
 		return nil, err
 	}
 	defer res.Body.Close()
@@ -217,7 +216,7 @@ func getProofsFromNode(queue chan []ProofBody, w *sync.WaitGroup, uri string, ha
 	res, err := client.Do(req)
 	if err != nil {
 		w.Add(-1)
-		Log.WarningF("Failed to retrieve Proofs from URI=%s; %s\n", uri, err.Error())
+		Log.Warningf("Failed to retrieve Proofs from URI=%s; %s\n", uri, err.Error())
 		return
 	}
 	defer res.Body.Close()
@@ -240,7 +239,7 @@ func submitHashesToNode(queue chan SubmitHashesResponse, w *sync.WaitGroup, uri 
 	res, err := http.Post(fmt.Sprintf("%s/hashes", uri.PublicUri), "application/json", bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		w.Add(-1)
-		Log.WarningF("Failed to submit hashes to Chainpoint Node URI=%s; %s\n", uri.PublicUri, err.Error())
+		Log.Warningf("Failed to submit hashes to Chainpoint Node URI=%s; %s\n", uri.PublicUri, err.Error())
 		return
 	}
 	defer res.Body.Close()


### PR DESCRIPTION
# Overview:
This package allows you to submit hashes to nodes on the Chainpoint Network that will subsequently anchor data to the Bitcoin blockchain. This allows one to cryptgraphically prove that a particular piece of data existed at a point in time.

## Methods:

### 1) SubmitHashes(uris NodeList, hashes []string)

The SubmitHashes function will submit a list of hashes to every Chainpoint Node provided to it via the function's first argument `uris` of type `NodeList`. Submitting to multiple Chainpoint Nodes to achieve your required level of redundancy is advised. Only a single Chainpoint Proof is required to attest the existence of your data.

The SubmitHashes function will return an array of `ProofHandles[]`:
```
type ProofHandle struct {
	Hash       string `json:"hash"`
	HashIDNode string `json:"hashIdNode"`
	Uri        string `json:"uri"`
}
```

> Note: The HashIDNode value being returned is a UUID V1

#### Example:
```
var RANDOM_NODES = []Node{{PublicUri: "http://10.0.0.0"}, {PublicUri: "http://10.0.0.1"}}

hashes := []string{"1957db7fe23e4be1740ddeb941ddda7ae0a6b782e536a9e00b5aa82db1e84547"}
proofHandles, err := SubmitHashes(RANDOM_NODES, hashes)
```

The result returned by SubmitHashes is of type `[]ProofHandle`

```
type ProofHandle struct {
	Hash       string `json:"hash"`
	HashIDNode string `json:"hashIdNode"`
	Uri        string `json:"uri"`
}
```

### 2) GetProofs(proofHandles []ProofHandle)

The GetProofs function accepts a list of Proof Handles and will retrieve their corresponding Chainpoint Proofs. This function includes the subtle optimization of grouping Proof Handles by Chainpoint Node PublicUri's and will issue one HTTP GET request with an embedded header value consisting of a comma-delimited string of hashIdNode values dictating which Proofs need to be resolved and returned to the requestor.

The GetProofs functions returns a type of `[]ProofBody`

```
type ProofBody struct {
	Anchors    []interface{} `json:"anchors_complete"`
	HashIDNode string        `json:"hash_id_node"`
	Proof      interface{}   `json:"proof"`
}
```

By default, the Proof returned is a base64 encoded string and is essentially the only piece of data that needs to be persisted. This base64 encoded Proof will be used in any requests to verify the integrity of a Proof.


#### Example:

```
// Step #1: Submit Hashes
proofHandles, err := SubmitHashes(RANDOM_NODES, hashes)

// Delaying the invocation to `GetProofs` is required due to the nature of how the Chainpoint Network operates. More info as to why can be provided upon request.
time.Sleep(18 * time.Second)

// Step #2: Provide the returned `Proof Handles` result from invoking `SubmiHashes()` as the only argument to `GetProofs()`
proofs, err := GetProofs(proofHandles)
```

### 3) VerifyProofs(proofs []string)

The VerifyProofs function accepts a list of base64 encode strings that will be submitted to any Chainpoint Node for verification. The verification process will perform the required cryptorgraphic operations for both `cal` and `btc` branches to verify the integrity of the Chainpoint Proof(s) that have been submitted.

#### Example:
```
// Step #1: Submit Hashes
proofHandles, err := SubmitHashes(RANDOM_NODES, hashes)

// Delaying the invocation to `GetProofs` is required due to the nature of how the Chainpoint Network operates. More info as to why can be provided upon request.
time.Sleep(18 * time.Second)

// Step #2: Provide the returned `Proof Handles` result from invoking `SubmiHashes()` as the only argument to `GetProofs()`
proofs, err := GetProofs(proofHandles)

// Step #3: Provide the returned `Proof` base64 encode strings that were returned from the `GetProofs()` function call as the only argument to `VerifyProofs()`
verifiedProofs, err := VerifyProofs([]string{"<base64EncodedProof>, ..."})
```

The call to VerifyProofs() will return a list of Proof verifications that have the following type:

```
type VerifiedProofs []struct {
	ProofIndex          int       `json:"proof_index"`
	Hash                string    `json:"hash"`
	HashIDNode          string    `json:"hash_id_node"`
	HashSubmittedNodeAt time.Time `json:"hash_submitted_node_at"`
	HashIDCore          string    `json:"hash_id_core"`
	HashSubmittedCoreAt time.Time `json:"hash_submitted_core_at"`
	Anchors             []struct {
		Branch string `json:"branch"`
		Type   string `json:"type"`
		Valid  bool   `json:"valid"`
	} `json:"anchors"`
	Status string `json:"status"`
}
```

# Pull Request Comments:

* Please provide any feedback regarding design patterns, coding style guide faults, etc. that are of concern so they can be resolved.
* Unit tests are coming soon!